### PR TITLE
Add posix_fadvise with POSIX_FADV_SEQUENTIAL

### DIFF
--- a/filerec.c
+++ b/filerec.c
@@ -423,7 +423,8 @@ int filerec_open(struct filerec *file, int write)
 				ret, strerror(ret), file->filename, write);
 			goto out_unlock;
 		}
-
+		
+		posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 		file->fd = fd;
 	}
 	file->fd_refs++;

--- a/filerec.c
+++ b/filerec.c
@@ -423,7 +423,7 @@ int filerec_open(struct filerec *file, int write)
 				ret, strerror(ret), file->filename, write);
 			goto out_unlock;
 		}
-		
+
 		posix_fadvise(fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 		file->fd = fd;
 	}


### PR DESCRIPTION
posix_fadvise system call was added in function filerec_open to speed up disk reading operations.